### PR TITLE
feat: func to manage aws auth configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.17
 
 require (
 	github.com/catalystsquad/app-utils-go v1.0.0
+	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0
 	github.com/pulumi/pulumi/sdk/v3 v3.25.1
+	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
 
@@ -59,6 +61,5 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -248,9 +248,12 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1 h1:nfvsZ4XUA865Rjq1YTQz99LkCw3fHZxuhGXB7ZPQmts=
+github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1/go.mod h1:bxyJjmoJcz/LQSy+oIrcag1Nio7RWMBJb6me/WV3Llw=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0 h1:raPMtrMu7bIQ0yYM4T23/xDIx14moiwz53s3kJoiCuE=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0/go.mod h1:w+Y1d8uqc+gv7JYWLF4rfzvTsIIHR1SCL+GG6sX1xMM=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
+github.com/pulumi/pulumi/sdk/v3 v3.25.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
 github.com/pulumi/pulumi/sdk/v3 v3.25.1 h1:Fj0LdbkmYmYq3fDNiDQ9JsuAPrTBLJBKR1uiisv2pAc=
 github.com/pulumi/pulumi/sdk/v3 v3.25.1/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/pkg/eks/authconfig.go
+++ b/pkg/eks/authconfig.go
@@ -1,0 +1,204 @@
+package eks
+
+import (
+	"errors"
+	"fmt"
+	"github.com/catalystsquad/pulumi-modules-go/pkg/utils"
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"strings"
+
+	// use yaml v2 because it uses indentation that matches the default
+	// aws-auth configmap, so that the initial import does not fail
+	"gopkg.in/yaml.v2"
+)
+
+type AuthConfigMapInput struct {
+	// disables all extra auth configuration, so that the configmap can be
+	// imported by pulumi. set this value to true on new clusters, disable
+	// after the configmap is imported and all additional permissions will be
+	// added
+	InitialImport bool `json:"initial-import"`
+
+	// required
+	NodeGroupIamRole string `json:"nodegroup-iam-role"`
+
+	// optional list of AWS SSO permission set roles to autodiscover
+	AutoDiscoverSSORoles []SSORolePermissionSetInput `json:"sso-permission-set-roles"`
+
+	// optional list of IAM roles and users
+	IAMRoles []IAMIdentityInput `json:"iam-roles"`
+	IAMUsers []IAMIdentityInput `json:"iam-users"`
+}
+
+type SSORolePermissionSetInput struct {
+	// name of permission set to discover for use in configmap
+	Name string `json:"name"`
+
+	// required groups to add role to
+	PermissionGroups []string `json:"permission-groups"`
+
+	// optional username field, defaults to name field
+	Username string `json:"username"`
+}
+
+type IAMIdentityInput struct {
+	// arn of IAM role to use in configmap
+	Arn string `json:"arn"`
+
+	// required groups to add role to
+	PermissionGroups []string `json:"permission-groups"`
+
+	// optional username field, defaults to role name
+	Username string `json:"username"`
+}
+
+type MapRolesElement struct {
+	Groups   []string `yaml:"groups"`
+	RoleArn  string   `yaml:"rolearn"`
+	Username string   `yaml:"username"`
+}
+
+type MapUsersElement struct {
+	Groups   []string `yaml:"groups"`
+	UserArn  string   `yaml:"userarn"`
+	Username string   `yaml:"username"`
+}
+
+var ssoRolePathPrefix string = "/aws-reserved/sso.amazonaws.com/"
+
+func SyncAuthConfigMap(ctx *pulumi.Context, config AuthConfigMapInput) error {
+	var mapRoles []MapRolesElement
+	var mapUsers []MapUsersElement
+	authConfigMapData := make(map[string]string)
+
+	// add nodegroup iam role to mapRoles
+	mapRoles = append(mapRoles, MapRolesElement{
+		RoleArn:  config.NodeGroupIamRole,
+		Username: "system:node:{{EC2PrivateDNSName}}",
+		Groups: []string{
+			"system:bootstrappers",
+			"system:nodes",
+		},
+	})
+
+	if !config.InitialImport {
+		// add all sso autodiscovery roles
+		for _, ssoRoleConfig := range config.AutoDiscoverSSORoles {
+			// default username to the permissionset name
+			username := ssoRoleConfig.Name
+			if ssoRoleConfig.Username != "" {
+				username = ssoRoleConfig.Username
+			}
+
+			roleArn, err := discoverSSORole(ctx, ssoRoleConfig.Name)
+			if err != nil {
+				return err
+			}
+
+			mapRoles = append(mapRoles, MapRolesElement{
+				RoleArn:  removeArnPath(roleArn),
+				Username: username,
+				Groups:   ssoRoleConfig.PermissionGroups,
+			})
+		}
+
+		// add all iam roles
+		for _, roleConfig := range config.IAMRoles {
+			// default username to the role name, derived from the role arn
+			username := arnToUsername(roleConfig.Arn)
+			if roleConfig.Username != "" {
+				username = roleConfig.Username
+			}
+
+			mapRoles = append(mapRoles, MapRolesElement{
+				RoleArn:  removeArnPath(roleConfig.Arn),
+				Username: username,
+				Groups:   roleConfig.PermissionGroups,
+			})
+		}
+
+		// add all iam users
+		for _, userConfig := range config.IAMUsers {
+			// default username to the role name, derived from the role arn
+			username := arnToUsername(userConfig.Arn)
+			if userConfig.Username != "" {
+				username = userConfig.Username
+			}
+
+			mapUsers = append(mapUsers, MapUsersElement{
+				UserArn:  removeArnPath(userConfig.Arn),
+				Username: username,
+				Groups:   userConfig.PermissionGroups,
+			})
+		}
+	}
+
+	// marshal all the data fields
+	mapRolesBytes, err := yaml.Marshal(&mapRoles)
+	if err != nil {
+		return err
+	}
+	authConfigMapData["mapRoles"] = string(mapRolesBytes)
+
+	// omit mapUsers if empty, otherwise import fails
+	if len(mapUsers) != 0 {
+		mapUsersBytes, err := yaml.Marshal(&mapUsers)
+		if err != nil {
+			return err
+		}
+		authConfigMapData["mapUsers"] = string(mapUsersBytes)
+	}
+
+	_, err = corev1.NewConfigMap(ctx, "aws-auth-configmap", &corev1.ConfigMapArgs{
+		Data: pulumi.ToStringMap(authConfigMapData),
+		Metadata: metav1.ObjectMetaArgs{
+			Name:      pulumi.String("aws-auth"),
+			Namespace: pulumi.String("kube-system"),
+		},
+	}, utils.GetImportOpt("kube-system/aws-auth"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func discoverSSORole(ctx *pulumi.Context, permissionSetName string) (roleArn string, err error) {
+	ssoRoleRegex := fmt.Sprintf("AWSReservedSSO_%s_.*", permissionSetName)
+
+	discoverSSORole, err := iam.GetRoles(ctx, &iam.GetRolesArgs{
+		NameRegex:  pulumi.StringRef(ssoRoleRegex),
+		PathPrefix: &ssoRolePathPrefix,
+	})
+	if err != nil {
+		return
+	}
+
+	// fail if we don't discover just 1 role
+	if len(discoverSSORole.Arns) != 1 {
+		err = errors.New(fmt.Sprintf(
+			"admin role auto discovery failed, discovered %d",
+			len(discoverSSORole.Arns),
+		))
+		return
+	}
+
+	roleArn = discoverSSORole.Arns[0]
+	return
+}
+
+// auth configmap doesn't support arns with paths, so we have to remove them
+// https://docs.aws.amazon.com/eks/latest/userguide/troubleshooting_iam.html#security-iam-troubleshoot-ConfigMap
+func removeArnPath(arn string) string {
+	a := strings.Split(arn, "/")
+	return strings.Join([]string{a[0], a[len(a)-1]}, "/")
+}
+
+// trim an ARN to use in the username field
+func arnToUsername(i string) string {
+	a := strings.Split(i, "/")
+	return a[len(a)-1]
+}


### PR DESCRIPTION
example direct usage:
```
package main

import (
	"github.com/catalystsquad/pulumi-modules-go/pkg/eks"
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		err := authconfig.SyncAuthConfigMap(ctx, authconfig.AuthConfigMapInput{
			NodeGroupIamRole: "arn:aws:iam::941986904600:role/nodegroup-iam-role-767653c",
			AutoDiscoverSSORoles: []authconfig.SSORolePermissionSetInput{{
				Name: "admin",
				PermissionGroups: []string{"system:masters"},
			}},
		})
		if err != nil {
			return err
		}

		return nil
	})
}

```