### PR TITLE
fix: use command provider to sync aws-auth configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/catalystsquad/app-utils-go v1.0.2
 	github.com/joomcode/errorx v1.1.0
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
+	github.com/pulumi/pulumi-command/sdk v0.0.3
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0
 	github.com/pulumi/pulumi/sdk/v3 v3.25.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,11 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1 h1:nfvsZ4XUA865Rjq1YTQz99LkCw3fHZxuhGXB7ZPQmts=
 github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1/go.mod h1:bxyJjmoJcz/LQSy+oIrcag1Nio7RWMBJb6me/WV3Llw=
+github.com/pulumi/pulumi-command/sdk v0.0.3 h1:APhWyBSjCp94b5VTVPz0GwwhP//HT22CD7cBQ0JhAic=
+github.com/pulumi/pulumi-command/sdk v0.0.3/go.mod h1:WtWndGuQusF2p68t6xEa9yQy6ObMJugKigB2hN4dzts=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0 h1:raPMtrMu7bIQ0yYM4T23/xDIx14moiwz53s3kJoiCuE=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.16.0/go.mod h1:w+Y1d8uqc+gv7JYWLF4rfzvTsIIHR1SCL+GG6sX1xMM=
+github.com/pulumi/pulumi/sdk/v3 v3.7.0/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
 github.com/pulumi/pulumi/sdk/v3 v3.25.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
 github.com/pulumi/pulumi/sdk/v3 v3.25.1 h1:Fj0LdbkmYmYq3fDNiDQ9JsuAPrTBLJBKR1uiisv2pAc=
@@ -415,6 +418,7 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/eks/authconfig.go
+++ b/pkg/eks/authconfig.go
@@ -89,6 +89,7 @@ var ssoRolePathPrefix string = "/aws-reserved/sso.amazonaws.com/"
 func SyncAuthConfigMap(ctx *pulumi.Context, config AuthConfigMapInput) error {
 	var authConfigMap ConfigMap = ConfigMap{
 		ApiVersion: "v1",
+		Data: map[string]string{},
 		Kind:       "ConfigMap",
 		Metadata: ConfigMapMetadata{
 			Name:      "aws-auth",

--- a/pkg/eks/authconfig.go
+++ b/pkg/eks/authconfig.go
@@ -3,12 +3,12 @@ package eks
 import (
 	"errors"
 	"fmt"
-	"github.com/catalystsquad/pulumi-modules-go/pkg/utils"
+	"github.com/catalystsquad/app-utils-go/errorutils"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
-	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"os"
 	"strings"
 
 	// use yaml v2 because it uses indentation that matches the default
@@ -72,12 +72,31 @@ type MapUsersElement struct {
 	Username string   `yaml:"username"`
 }
 
+type ConfigMap struct {
+	ApiVersion string            `yaml:"apiVersion"`
+	Data       map[string]string `yaml:"data"`
+	Kind       string            `yaml:"kind"`
+	Metadata   ConfigMapMetadata `yaml:"metadata"`
+}
+
+type ConfigMapMetadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
 var ssoRolePathPrefix string = "/aws-reserved/sso.amazonaws.com/"
 
 func SyncAuthConfigMap(ctx *pulumi.Context, config AuthConfigMapInput) error {
+	var authConfigMap ConfigMap = ConfigMap{
+		ApiVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: ConfigMapMetadata{
+			Name:      "aws-auth",
+			Namespace: "kube-system",
+		},
+	}
 	var mapRoles []MapRolesElement
 	var mapUsers []MapUsersElement
-	authConfigMapData := make(map[string]string)
 
 	var nodeRoleArn string
 	var err error
@@ -165,7 +184,7 @@ func SyncAuthConfigMap(ctx *pulumi.Context, config AuthConfigMapInput) error {
 	if err != nil {
 		return err
 	}
-	authConfigMapData["mapRoles"] = string(mapRolesBytes)
+	authConfigMap.Data["mapRoles"] = string(mapRolesBytes)
 
 	// omit mapUsers if empty, otherwise import fails
 	if len(mapUsers) != 0 {
@@ -173,21 +192,13 @@ func SyncAuthConfigMap(ctx *pulumi.Context, config AuthConfigMapInput) error {
 		if err != nil {
 			return err
 		}
-		authConfigMapData["mapUsers"] = string(mapUsersBytes)
+		authConfigMap.Data["mapUsers"] = string(mapUsersBytes)
 	}
 
-	_, err = corev1.NewConfigMap(ctx, "aws-auth-configmap", &corev1.ConfigMapArgs{
-		Data: pulumi.ToStringMap(authConfigMapData),
-		Metadata: metav1.ObjectMetaArgs{
-			Name:      pulumi.String("aws-auth"),
-			Namespace: pulumi.String("kube-system"),
-		},
-	}, utils.GetImportOpt("kube-system/aws-auth"))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// marshal configmap
+	configMapYaml, err := yaml.Marshal(&authConfigMap)
+	applyKubernetesManifest(ctx, "aws-auth-configmap", configMapYaml)
+	return err
 }
 
 // assumes that all nodegroups have the same IAM role, so only finds the first
@@ -201,7 +212,7 @@ func discoverNodeIAMRole(ctx *pulumi.Context, clusterName string) (roleArn strin
 	}
 
 	nodegroup, err := eks.LookupNodeGroup(ctx, &eks.LookupNodeGroupArgs{
-		ClusterName: clusterName,
+		ClusterName:   clusterName,
 		NodeGroupName: nodegroups.Names[0],
 	})
 	if err != nil {
@@ -247,4 +258,26 @@ func removeArnPath(arn string) string {
 func arnToUsername(i string) string {
 	a := strings.Split(i, "/")
 	return a[len(a)-1]
+}
+
+func applyKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, manifest []byte) error {
+	// write bytes to file
+	tempFileName := fmt.Sprintf("/tmp/%s.yaml", pulumiResourceName)
+	err := os.WriteFile(tempFileName, manifest, 0644)
+	errorutils.LogOnErr(nil, "error writing manifest to file", err)
+	if err != nil {
+		return err
+	}
+	// defer file deletion
+	defer func() {
+		err = os.Remove(tempFileName)
+		errorutils.LogOnErr(nil, "error deleting manifest file", err)
+	}()
+	// execute kubectl apply
+	_, err = local.NewCommand(ctx, pulumiResourceName, &local.CommandArgs{
+		Create:   pulumi.String(fmt.Sprintf("kubectl apply -f %s", tempFileName)),
+		Triggers: pulumi.ToArrayOutput([]pulumi.Output{pulumi.ToOutput(string(manifest))}),
+	})
+	errorutils.LogOnErr(nil, "error running kubectl apply", err)
+	return err
 }


### PR DESCRIPTION
the kubernetes provider is really bad about imports and managing this
configmap with it has proven difficult. this implements a work around by
running kubectl apply directly.
