### PR TITLE
fix: allow any ResourceOption configuration in SyncKubernetesManifest

### DIFF
--- a/pkg/kubernetes/argocd-application.go
+++ b/pkg/kubernetes/argocd-application.go
@@ -7,9 +7,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SyncArgocdApplication takes in a pulumi resource name, an argocd application, and an optional id (arn, uuid, depends on what the resource is)
+// SyncArgocdApplication takes in a pulumi resource name, an argocd application, and any pulumi options
 // It will replace secrets in the spec.source.helm.values with the configured secrets provider, then sync the resulting yaml to k8s
-func SyncArgocdApplication(ctx *pulumi.Context, pulumiResourceName string, application ArgocdApplication, id string) error {
+func SyncArgocdApplication(ctx *pulumi.Context, pulumiResourceName string, application ArgocdApplication, opts ...pulumi.ResourceOption) error {
 	// replace secrets in values
 	err := ReplaceSecretsInValues(ctx, &application)
 	errorutils.LogOnErr(nil, "error replacing secrets in values", err)
@@ -22,7 +22,7 @@ func SyncArgocdApplication(ctx *pulumi.Context, pulumiResourceName string, appli
 	if err != nil {
 		return err
 	}
-	return SyncKubernetesManifest(ctx, pulumiResourceName, bytes, id)
+	return SyncKubernetesManifest(ctx, pulumiResourceName, bytes, opts...)
 }
 
 // NewApplicationFromBytes transforms yaml formatted byte array into an ArgocdApplication struct

--- a/pkg/kubernetes/argocd-application.go
+++ b/pkg/kubernetes/argocd-application.go
@@ -9,18 +9,18 @@ import (
 
 // SyncArgocdApplication takes in a pulumi resource name, an argocd application, and any pulumi options
 // It will replace secrets in the spec.source.helm.values with the configured secrets provider, then sync the resulting yaml to k8s
-func SyncArgocdApplication(ctx *pulumi.Context, pulumiResourceName string, application ArgocdApplication, opts ...pulumi.ResourceOption) error {
+func SyncArgocdApplication(ctx *pulumi.Context, pulumiResourceName string, application ArgocdApplication, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	// replace secrets in values
 	err := ReplaceSecretsInValues(ctx, &application)
 	errorutils.LogOnErr(nil, "error replacing secrets in values", err)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// marshall application to yaml
 	bytes, err := yaml.Marshal(application)
 	errorutils.LogOnErr(nil, "error marshalling application to yaml", err)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return SyncKubernetesManifest(ctx, pulumiResourceName, bytes, opts...)
 }

--- a/pkg/kubernetes/bootstrap.go
+++ b/pkg/kubernetes/bootstrap.go
@@ -74,15 +74,17 @@ func BootstrapCluster(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+
 	// deploy cluster argocd application
 	platformApplication, err := deployPlatformApplicationManifest(ctx, pulumi.DependsOn([]pulumi.Resource{argocd})) // depend on argocd for application CRDs
 	errorutils.LogOnErr(nil, "error deploying cluster application manifest", err)
-	// create cert-manager dns secret
-	err = deployCertManagerDnsSolverSecret(ctx, pulumi.DependsOn([]pulumi.Resource{platformApplication}))
-	errorutils.LogOnErr(nil, "error deploying cert manager dns solver secret", err)
 	if err != nil {
 		return err
 	}
+
+	// create cert-manager dns secret
+	err = deployCertManagerDnsSolverSecret(ctx, pulumi.DependsOn([]pulumi.Resource{platformApplication}))
+	errorutils.LogOnErr(nil, "error deploying cert manager dns solver secret", err)
 	return err
 }
 

--- a/pkg/kubernetes/manifest.go
+++ b/pkg/kubernetes/manifest.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"github.com/catalystsquad/app-utils-go/errorutils"
-	"github.com/catalystsquad/pulumi-modules-go/pkg/utils"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/yaml"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"os"
@@ -14,7 +13,7 @@ import (
 // Pulumi creates the k8s resources from the config file. Recommended use is to store your manifests in yaml file,
 // embed them, template them with pulumi secrets, or variables, and then pass them to this method to sync
 // the kubernetes resource, whatever it may be.
-func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, manifest []byte, id string) error {
+func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, manifest []byte, opts ...pulumi.ResourceOption) error {
 	// write bytes to file
 	tempFileName := fmt.Sprintf("/tmp/%s.yaml", pulumiResourceName)
 	err := os.WriteFile(tempFileName, manifest, 0644)
@@ -30,7 +29,7 @@ func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, mani
 	// get pulumi configfile from written manifest
 	_, err = yaml.NewConfigFile(ctx, pulumiResourceName, &yaml.ConfigFileArgs{
 		File: tempFileName,
-	}, utils.GetImportOpt(id))
+	}, opts...)
 	errorutils.LogOnErr(nil, "error getting pulumi configfile from manifest file", err)
 	return err
 }

--- a/pkg/kubernetes/manifest.go
+++ b/pkg/kubernetes/manifest.go
@@ -13,13 +13,13 @@ import (
 // Pulumi creates the k8s resources from the config file. Recommended use is to store your manifests in yaml file,
 // embed them, template them with pulumi secrets, or variables, and then pass them to this method to sync
 // the kubernetes resource, whatever it may be.
-func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, manifest []byte, opts ...pulumi.ResourceOption) error {
+func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, manifest []byte, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	// write bytes to file
 	tempFileName := fmt.Sprintf("/tmp/%s.yaml", pulumiResourceName)
 	err := os.WriteFile(tempFileName, manifest, 0644)
 	errorutils.LogOnErr(nil, "error writing manifest to file", err)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// defer file deletion
 	defer func() {
@@ -27,9 +27,9 @@ func SyncKubernetesManifest(ctx *pulumi.Context, pulumiResourceName string, mani
 		errorutils.LogOnErr(nil, "error deleting manifest file", err)
 	}()
 	// get pulumi configfile from written manifest
-	_, err = yaml.NewConfigFile(ctx, pulumiResourceName, &yaml.ConfigFileArgs{
+	resource, err := yaml.NewConfigFile(ctx, pulumiResourceName, &yaml.ConfigFileArgs{
 		File: tempFileName,
 	}, opts...)
 	errorutils.LogOnErr(nil, "error getting pulumi configfile from manifest file", err)
-	return err
+	return resource, err
 }


### PR DESCRIPTION
so that any resource option can be specified, rather implementing each resource option as they become a requirement

adds a dependsOn to the cluster services helm release, so that it waits for argocd to be deployed first, otherwise we don't have application CRDs

add depends on to deployCertManager secret for the platform application, otherwise the resource fails to create because the namespace doesn't exist.